### PR TITLE
cms: remove the use of KeyWrap, use Kek directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 name = "aes-kw"
 version = "0.3.0-pre"
-source = "git+https://github.com/RustCrypto/key-wraps.git#c9437ce4933822252863fd64fc06c631405ad8b1"
+source = "git+https://github.com/RustCrypto/key-wraps.git#bb4402822ec6b876d87b85f6495b8a4ca9a295bd"
 dependencies = [
  "aes",
  "const-oid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,11 +78,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 [[package]]
 name = "ansi-x963-kdf"
 version = "0.1.0"
-<<<<<<< HEAD
-source = "git+https://github.com/RustCrypto/KDFs.git#0e6724b1b730ab378b7cfdc1c23089b0033ebced"
-=======
 source = "git+https://github.com/RustCrypto/KDFs.git#6f0b04d3fc1e6b7b7fa1ebca4d2be52d9e107dc9"
->>>>>>> 92cc970 (cms: ecc-kari support - move KeyAgreeRecipientInfoBuilder to sub-module)
 dependencies = [
  "digest",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ x509-ocsp = { path = "./x509-ocsp" }
 
 # https://github.com/RustCrypto/key-wraps/pull/34
 # https://github.com/RustCrypto/key-wraps/pull/35
+# https://github.com/RustCrypto/key-wraps/pull/39
 aes-kw = { git = "https://github.com/RustCrypto/key-wraps.git" }
+
 
 # https://github.com/RustCrypto/KDFs/pull/102
 ansi-x963-kdf = { git = "https://github.com/RustCrypto/KDFs.git" }

--- a/cms/src/builder.rs
+++ b/cms/src/builder.rs
@@ -52,7 +52,7 @@ mod utils;
 
 // Exports
 pub use kari::{EcKeyEncryptionInfo, KeyAgreeRecipientInfoBuilder, KeyAgreementAlgorithm};
-pub use utils::kw::{KeyWrap, KeyWrapAlgorithm};
+pub use utils::kw::KeyWrapAlgorithm;
 
 /// Error type
 #[derive(Debug)]

--- a/cms/tests/builder/kari.rs
+++ b/cms/tests/builder/kari.rs
@@ -1,7 +1,8 @@
+use aes_kw::AesKw;
 use cms::{
     builder::{
         ContentEncryptionAlgorithm, EcKeyEncryptionInfo, EnvelopedDataBuilder,
-        KeyAgreeRecipientInfoBuilder, KeyAgreementAlgorithm, KeyWrap,
+        KeyAgreeRecipientInfoBuilder, KeyAgreementAlgorithm,
     },
     cert::IssuerAndSerialNumber,
     content_info::ContentInfo,
@@ -41,15 +42,14 @@ fn test_build_enveloped_data_ec() {
 
     // KARI builder
     let mut rng = OsRng;
-    let kari_builder =
-        KeyAgreeRecipientInfoBuilder::<_, _, KeyWrap<aes::Aes192>, aes::Aes128>::new(
-            None,
-            key_agreement_recipient_identifier,
-            EcKeyEncryptionInfo::Ec(recipient_public_key),
-            KeyAgreementAlgorithm::SinglePassStdDhSha256Kdf,
-            &mut rng,
-        )
-        .expect("Could not create a KeyAgreeRecipientInfoBuilder");
+    let kari_builder = KeyAgreeRecipientInfoBuilder::<_, _, AesKw<aes::Aes192>, aes::Aes128>::new(
+        None,
+        key_agreement_recipient_identifier,
+        EcKeyEncryptionInfo::Ec(recipient_public_key),
+        KeyAgreementAlgorithm::SinglePassStdDhSha256Kdf,
+        &mut rng,
+    )
+    .expect("Could not create a KeyAgreeRecipientInfoBuilder");
 
     // Enveloped data builder
     let mut rng = OsRng;


### PR DESCRIPTION
This brings a merge of `origin/master` because `const-oid` got bumped, ideally the whole branch needs a rebase.

Only the last commit is required here.